### PR TITLE
Allow scrolling except for navigation and background

### DIFF
--- a/react-multi-page-website/src/index.css
+++ b/react-multi-page-website/src/index.css
@@ -12,7 +12,9 @@ body {
   background-color: #66d9ff;
   height: 100vh;
   background-image: linear-gradient(#0099cc, #99e6ff);
-  overflow: hidden;
+  /* overflow: hidden; */
+  background-attachment: fixed;
+  /* display: flex; */
 }
 
 code {

--- a/react-multi-page-website/src/pages/About.jsx
+++ b/react-multi-page-website/src/pages/About.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 function About() {
   return (
-    <div className="about">
+    <div class="content-container">
       <div class="container">
         <div class="row align-items-center my-5">
           <div class="col-lg-7">

--- a/react-multi-page-website/src/pages/Contact.jsx
+++ b/react-multi-page-website/src/pages/Contact.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 function Contact() {
   return (
-    <div className="contact">
+    <div class="content-container">
       <div class="container">
         <div class="row align-items-center my-5">
           <div class="col-lg-7">

--- a/react-multi-page-website/src/pages/Projects.jsx
+++ b/react-multi-page-website/src/pages/Projects.jsx
@@ -9,7 +9,7 @@ import Project from "./components/Project";
 
 function Projects() {
   return (
-    <div className="about">
+    <div className="content-container">
       <div class="container">
         <h1 class="font-weight-light">Projects</h1>
         <Project


### PR DESCRIPTION
## GitHub Issue Solved: 
closes #5 <!--Reference the number of the solved issue-->

## Current behaviour
<!--Please describe the current behaviour-->
You cannot scroll anywhere on the react site

## Changed behaviour
<!--Please describe the behaviour after the PR has been merged-->
If the content is cut off, you can now scoll.  The navigation and background do not scroll
