### PR TITLE
Resizable project component

### DIFF
--- a/react-multi-page-website/src/pages/components/Project.jsx
+++ b/react-multi-page-website/src/pages/components/Project.jsx
@@ -5,9 +5,28 @@ import { Carousel } from "react-responsive-carousel";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 
 function Project(props) {
+  /* Keeps track of the window dimensions.  Updates when window resizes */
+  const [dimensions, setDimensions] = React.useState({
+    height: window.innerHeight,
+    width: window.innerWidth,
+  });
+  React.useEffect(() => {
+    function handleResize() {
+      setDimensions({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      });
+    }
+
+    window.addEventListener("resize", handleResize);
+    return (_) => {
+      window.removeEventListener("resize", handleResize);
+    };
+  });
+
   return (
     <Grid container spacing={3}>
-      {!props.imgOnLeft && (
+      {(!props.imgOnLeft || dimensions.width < 600) && (
         <Grid item xs>
           <h2>
             {props.heading} - {props.subheading}
@@ -35,7 +54,7 @@ function Project(props) {
           </Carousel>
         </Grid>
       )}
-      {props.imgOnLeft && (
+      {(props.imgOnLeft && dimensions.width) >= 600 && (
         <Grid item xs>
           <Grid item xs>
             <h2>

--- a/react-multi-page-website/src/pages/components/Project.jsx
+++ b/react-multi-page-website/src/pages/components/Project.jsx
@@ -17,7 +17,7 @@ function Project(props) {
         </Grid>
       )}
       {props.images && (
-        <Grid item xs={4}>
+        <Grid item xs={12} sm={6} md={4}>
           <Carousel
             autoPlay
             showIndicators={props.images.length > 1}


### PR DESCRIPTION
## GitHub Issue Solved: 
closes #14 

## Current behaviour
The project component doesn't look nice in smaller window sizes
<!--Please describe the current behaviour-->

## Changed behaviour
The collumn sizes change when the window gets narrower.  If it is too small to fit multiple collumns, the content will appear first, with the carousal after
<!--Please describe the behaviour after the PR has been merged-->

